### PR TITLE
docs(nextjs): add info on opting out of client/server bundles

### DIFF
--- a/src/platforms/javascript/guides/nextjs/manual-setup.mdx
+++ b/src/platforms/javascript/guides/nextjs/manual-setup.mdx
@@ -415,3 +415,9 @@ const moduleExports = {
 Please note that this option will tunnel Sentry events through your Next.js application so you might experience increased server usage.
 
 Learn more about tunneling in the <PlatformLink to="/troubleshooting/#dealing-with-ad-blockers">troubleshooting section</PlatformLink>.
+
+### Opt Out of Sentry SDK bundling in Client or Server side
+
+If you want the `sentry` to be available in your server side & not in client side, you can make your `sentry.client.config.js` empty. This will prevent webpack from pulling in the Sentry related files when generating the browser bundle. The same goes the opposite for opting out of server side bundle by emptying `sentry.server.config.js`.
+
+You cannot delete the respective config files because the SDK requires you to have it.


### PR DESCRIPTION
Update the Next.js Manual Setup to include the following based on the issue https://github.com/getsentry/sentry-javascript/issues/6729

## Opt Out of Sentry SDK bundling in Client or Server side


If you want the `sentry` to be available in your server side & not in client side, you can make your `sentry.client.config.js` empty. This will prevent webpack from pulling in the Sentry related files when generating the browser bundle. The same goes the opposite for opting out of server side bundle by emptying `sentry.server.config.js`.

You cannot delete the respective config files because the SDK requires you to have it.

<!-- Describe your PR here. -->



<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
